### PR TITLE
correct nested custom children name, info, price as addon-{name, info, price} using template and slots

### DIFF
--- a/multi-step-form-main/assets/js/createTemplates.js
+++ b/multi-step-form-main/assets/js/createTemplates.js
@@ -1,11 +1,11 @@
 customElements.define(
-  "step-heading",
+  "name-ele",
   class extends HTMLElement {
     constructor() {
       super(); // Always call super first in constructor
-      const stepHeading = document.getElementById("step-heading").content;
+      const name = document.getElementById("nameEle").content;
       const shadowRoot = this.attachShadow({ mode: "open" });
-      shadowRoot.appendChild(stepHeading.cloneNode(true));
+      shadowRoot.appendChild(name.cloneNode(true));
     }
   }
 );

--- a/multi-step-form-main/assets/js/selectPlan.js
+++ b/multi-step-form-main/assets/js/selectPlan.js
@@ -148,10 +148,10 @@ function handleAddOn(e) {
     e.currentTarget.style.borderColor = ""; // Reset border color to default
     // update addOnsNameList and addOnsPriceList
     let n_index = addOnsNameList.indexOf(
-      e.currentTarget.querySelector("name").innerText.trim().toLowerCase()
+      e.currentTarget.querySelector("name-ele").innerText.trim().toLowerCase()
     );
     let p_index = addOnsPricelist.indexOf(
-      e.currentTarget.querySelector("price").innerText
+      e.currentTarget.querySelector("addon-price").innerText
     );
     console.log(
       "Removed name from the cart: ",
@@ -171,12 +171,17 @@ function handleAddOn(e) {
     e.currentTarget.classList.add("clicked");
     // get name and price of add ons
     addOnsNameList.push(
-      e.currentTarget.querySelector("name").innerText.trim().toLowerCase()
+      e.currentTarget.querySelector("name-ele").innerText.trim().toLowerCase()
     );
-    addOnsPricelist.push(e.currentTarget.querySelector("price").innerText);
+    addOnsPricelist.push(
+      e.currentTarget.querySelector("addon-price").innerText
+    );
 
-    showSelectedPlanCard(e.currentTarget, addOns);
-
+    // show selected card
+    e.currentTarget.style.backgroundColor = "hsl(231, 70%, 95%)";
+    e.currentTarget.style.borderColor = "hsl(243, 100%, 62%)";
+    // showSelectedPlanCard(e.currentTarget, addOns);
+    console.log(e.currentTarget);
     console.log("Updated cart with add-ons: ", addOnsNameList, addOnsPricelist);
   }
 
@@ -204,7 +209,7 @@ function showPrice(priceArray1, priceArray2, billing, cardsList1, cardsList2) {
 
   let j = 0;
   cardsList2.forEach((card) => {
-    card.querySelector("price").innerText =
+    card.querySelector("addon-price").innerText =
       "+$" + `${priceArray2[j]}/${billing}`;
     j++;
   });
@@ -215,10 +220,10 @@ function showPrice(priceArray1, priceArray2, billing, cardsList1, cardsList2) {
 
     if (
       addOnsNameList.includes(
-        card.querySelector("name").innerText.trim().toLowerCase()
+        card.querySelector("name-ele").innerText.trim().toLowerCase()
       )
     ) {
-      addOnsPricelist.push(card.querySelector("price").innerText);
+      addOnsPricelist.push(card.querySelector("addon-price").innerText);
     }
   });
   return;
@@ -272,6 +277,7 @@ function createSummary() {
 }
 
 function handleLastStep(e) {
+  e.preventDefault();
   submitObject["total"] = summaryTotalEle.innerText;
 
   // activate last step

--- a/multi-step-form-main/index.html
+++ b/multi-step-form-main/index.html
@@ -179,16 +179,18 @@
       </div>
     </template>
 
+    <template id="nameEle"> <slot></slot> </template>
+
     <template id="addon-name">
-      <name>addon-name</name>
+      <slot> </slot>
     </template>
 
     <template id="addon-info">
-      <info>addon-info</info>
+      <slot> </slot>
     </template>
 
     <template id="addon-price">
-      <price>addon-price</price>
+      <slot> </slot>
     </template>
 
     <template id="add-on">
@@ -216,21 +218,21 @@
           gap: 0.5rem;
           cursor: pointer;
         }
-        ::slotted(:is(price, info)) {
+        ::slotted(:is(addon-price, addon-info)) {
           font-family: "ubuntu-regular", sans-serif;
           font-size: 1rem;
         }
-        ::slotted(price) {
+        ::slotted(addon-price) {
           color: hsl(243, 100%, 62%);
           margin-left: auto !important;
           align-self: center;
           flex-shrink: 0;
           flex-grow: 0;
         }
-        ::slotted(info) {
+        ::slotted(addon-info) {
           color: hsl(231, 6%, 48%);
         }
-        ::slotted(name) {
+        ::slotted(addon-name) {
           color: hsl(214, 54%, 36%);
           font-family: "ubuntu-bold", sans-serif;
           font-size: 1rem;
@@ -247,16 +249,10 @@
       <div class="addon-card">
         <input id="check" type="checkbox" />
         <label for="check">
-          <slot name="add-on-name">
-            <addon-name></addon-name>
-          </slot>
-          <slot name="add-on-info">
-            <addon-info></addon-info>
-          </slot>
+          <slot name="add-on-name"> </slot>
+          <slot name="add-on-info"> </slot>
         </label>
-        <slot name="add-on-price">
-          <addon-price>+$2/mo</addon-price>
-        </slot>
+        <slot name="add-on-price"> </slot>
       </div>
     </template>
 
@@ -457,20 +453,31 @@
         </step-heading>
 
         <form id="form-2" class="addon-container">
+          <!-- info is anonymous element -->
           <add-on>
-            <name slot="add-on-name">Online</name>
-            <info slot="add-on-info">service Access to multiplayer games</info>
-            <price slot="add-on-price">+$1/mo</price>
+            <addon-name slot="add-on-name">
+              <name-ele>Online</name-ele>
+            </addon-name>
+            <addon-info slot="add-on-info"
+              >service Access to multiplayer games</addon-info
+            >
+            <addon-price slot="add-on-price">+$1/mo </addon-price>
           </add-on>
           <add-on>
-            <name slot="add-on-name">Larger storage </name>
-            <info slot="add-on-info">Extra 1TB of cloud save</info>
-            <price slot="add-on-price">+$2/mo</price>
+            <addon-name slot="add-on-name">
+              <name-ele>Larger storage</name-ele></addon-name
+            >
+            <addon-info slot="add-on-info">Extra 1TB of cloud save</addon-info>
+            <addon-price slot="add-on-price">+$2/mo</addon-price>
           </add-on>
           <add-on>
-            <name slot="add-on-name">Customizable</name>
-            <info slot="add-on-info">Profile Custom theme on your profile</info>
-            <price slot="add-on-price">+$2/mo</price>
+            <addon-name slot="add-on-name">
+              <name-ele>Customizable</name-ele></addon-name
+            >
+            <addon-info slot="add-on-info"
+              >Profile Custom theme on your profile</addon-info
+            >
+            <addon-price slot="add-on-price">+$2/mo</addon-price>
           </add-on>
         </form>
 


### PR DESCRIPTION
Closes #23

Custom children elements were not propertly defined in HTML document. This PR is for fixing custom elements in html document. These elements are renamed as addon-{name, info, price} with empty slot elements. Some JavaScript selector API's are also renamed. 