### PR TITLE
Fix bud : mobile tooltip button click event

### DIFF
--- a/article-preview-component-master/script.js
+++ b/article-preview-component-master/script.js
@@ -2,8 +2,37 @@ const userShare = document.getElementsByClassName("user-share");
 const user = document.getElementsByClassName("user");
 const userImg = user[0].querySelector(".user-img");
 const userInfo = user[0].querySelector(".user-info");
-const desktopToolTip = userShare[0].querySelector("span");
 const mobileToolTip = document.querySelector(".mobile-tooltip");
+// const desktopToolTip = userShare[0].querySelector("span");
+
+// following event only of small screens
+
+userShare[0].addEventListener("click", handleClick);
+
+function handleClick() {
+  let userImage = userImg.style.visibility || "visible";
+  console.log(userImage);
+  userImage === "visible" ? handleHidden() : handleVisible();
+}
+
+// study purpose functions
+function handleHidden() {
+  console.log("handle hidden");
+  if (window.innerWidth < 650) {
+    userImg.style.visibility = "hidden";
+    userInfo.style.visibility = "hidden";
+    mobileToolTip.style.display = "flex";
+  }
+}
+
+function handleVisible() {
+  console.log("handle visible");
+  if (window.innerWidth < 650) {
+    userImg.style.visibility = "visible";
+    userInfo.style.visibility = "visible";
+    mobileToolTip.style.display = "none";
+  }
+}
 
 // This events are also emplemented in CSS by using :hover :focus for desktop
 // following events are implemented for study purpose
@@ -16,40 +45,11 @@ const mobileToolTip = document.querySelector(".mobile-tooltip");
 
 // userShare[0].addEventListener("focusout", handleVisible);
 
-// following event only of small screens
+// this event is fired on browser tab size change
+// window.addEventListener("resize", handleToolTip);
 
-userShare[0].addEventListener("click", handleClick);
-
-window.addEventListener("resize", handleToolTip);
-
-function handleToolTip() {
-  window.innerWidth < 650
-    ? (desktopToolTip.style.display = "none")
-    : (desktopToolTip.style.display = "block");
-}
-
-function handleClick() {
-  userImg.style.visibility === "visible" ? handleHidden() : handleVisible();
-}
-
-// study purpose functions
-function handleHidden() {
-  if (window.innerWidth < 650) {
-    userImg.style.visibility = "hidden";
-    userInfo.style.visibility = "hidden";
-
-    userShare[0].classList.remove("tooltip");
-    mobileToolTip.style.display = "flex";
-  }
-}
-
-function handleVisible() {
-  if (window.innerWidth < 650) {
-    const deleteChild = user[0].querySelector("span.mobile-tooltip");
-    userImg.style.visibility = "visible";
-    userInfo.style.visibility = "visible";
-
-    userShare[0].classList.add("tooltip");
-    mobileToolTip.style.display = "none";
-  }
-}
+// function handleToolTip() {
+//   window.innerWidth < 650
+//     ? (desktopToolTip.style.display = "none")
+//     : (desktopToolTip.style.display = "block");
+// }

--- a/article-preview-component-master/style.css
+++ b/article-preview-component-master/style.css
@@ -106,7 +106,6 @@ img.furniture {
 
 img.user-img {
   border-radius: 2em;
-  visibility: visible;
 }
 
 .user-info {
@@ -227,6 +226,11 @@ img.user-img {
     border-end-start-radius: 0;
   }
 
+  /* desktop tooltip closed on small screens */
+  .tooltiptext {
+    display: none;
+  }
+
   .user {
     position: relative;
   }
@@ -237,7 +241,7 @@ img.user-img {
     top: 2em;
     right: 1em;
   }
-
+  /* show mobile tooltip */
   .mobile-tooltip {
     position: absolute;
     bottom: 0;


### PR DESCRIPTION
- [X] remove "resize" event on window
- [X] use media query to display:none desktop tooltip on small screens
- [X] write function to handle click on small devices

Note:- HTMLElement.style.visibility returns empty string, even visibility property set on an element.
SO click event handler function has dummy variable with || (OR) condition value.